### PR TITLE
BUG: Fix notebook save not working

### DIFF
--- a/notedown/templates/markdown.tpl
+++ b/notedown/templates/markdown.tpl
@@ -1,4 +1,4 @@
-{% extends 'display_priority.tpl' %}
+{% extends 'base/display_priority.j2' %}
 
 {% block input %}
 {{ cell | create_input_codeblock }}

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ from setuptools import setup
 
 
 setup(
-    name="mu-notedown",
-    version="2.0.4",
+    name="d2l-notedown",
+    version="2.1.0",
     description="A fork of notedown",
     long_description='',
     packages=['notedown'],

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license='BSD 2-Clause',
     url='http://github.com/mli/notedown',
     install_requires=['nbformat',
-                      'nbconvert',
+                      'nbconvert>=6.2',
                       'pandoc-attributes',
                       'six'],
     entry_points={'console_scripts': ['notedown = notedown.main:app', ]},

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 
 setup(
     name="mu-notedown",
-    version="2.0.3",
+    version="2.0.4",
     description="A fork of notedown",
     long_description='',
     packages=['notedown'],


### PR DESCRIPTION
Fix notebook save error in d2lbook. See https://github.com/d2l-ai/d2l-book/issues/59 for detailed reference.
@mli please upload a new version of mu-notedown to pypi after merging this.

cc @astonzhang